### PR TITLE
fix: remove unsupported flag in wpm.json

### DIFF
--- a/wpm.json
+++ b/wpm.json
@@ -4,7 +4,7 @@
     "script": "./dist/web_interface.js",
     "instances": 1,
     "max_memory_restart": "128M",
-    "node_args": ["--nouse-idle-notification"],
+    "node_args": [],
     "env": {
       "NODE_ENV": "production"
     },


### PR DESCRIPTION
*Description of changes:* Remove unsupported flag in wpm.json that does not work with node 24 (and was a no-op since at least node 20).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
